### PR TITLE
Better data update scene and workflow

### DIFF
--- a/src/main/java/planner/App.java
+++ b/src/main/java/planner/App.java
@@ -298,6 +298,13 @@ public class App extends Application {
                 planSceneController.updateCycle();
             }
         });
+        mainController.getAttackersAdded().addListener((observable, oldValue, newValue) -> {
+            if (observable.getValue()) {
+                mainController.getAttackersAdded().set(false);
+                planSceneController.getOperation().addNewAttackers();
+                planSceneController.updateCycle();
+            }
+        });
     }
 
     private void initPlanController() throws IOException {

--- a/src/main/java/planner/App.java
+++ b/src/main/java/planner/App.java
@@ -60,7 +60,7 @@ public class App extends Application {
         this.initPlanController();
         this.initCommandController();
 
-        stage.setTitle("Planner 1.03-dev");
+        stage.setTitle("Planner 1.03");
         stage.setScene(planScene);
         stage.show();
 

--- a/src/main/java/planner/App.java
+++ b/src/main/java/planner/App.java
@@ -44,14 +44,18 @@ public class App extends Application {
         this.stage = stage;
 
         this.readyDb();
+        this.downloadMapSql();
 
         this.initMainController();
         this.initPlanController();
         this.initCommandController();
 
-        stage.setTitle("Planner 1.02");
-        stage.setScene(mainScene);
+        stage.setTitle("Planner 1.03-dev");
+        stage.setScene(planScene);
         stage.show();
+
+        planSceneController.loadOperation();
+        planSceneController.updateCycle();
     }
 
 
@@ -169,6 +173,11 @@ public class App extends Application {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+
+    private void downloadMapSql() {
+
     }
 
 

--- a/src/main/java/planner/CommandController.java
+++ b/src/main/java/planner/CommandController.java
@@ -148,7 +148,7 @@ public class CommandController implements Initializable {
                 .append(" // [b]")
                 .append(attack.getLandingTime().format(App.TIME_ONLY))
                 .append(" ")
-                .append(attack.getLandingTime().format(App.TIME_ONLY))
+                .append(attack.getLandingTime().format(App.DAY_AND_MONTH))
                 .append("[/b] [x|y]")
                 .append(attack.getTarget().getCoords())
                 .append("[/x|y] ");

--- a/src/main/java/planner/GSDebugger.java
+++ b/src/main/java/planner/GSDebugger.java
@@ -1,5 +1,6 @@
 package planner;
 
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -19,7 +20,12 @@ public class GSDebugger {
 
     public static void main(String[] args) {
 
-        Operation operation = Operation.load();
+        Operation operation = null;
+        try {
+            operation = Operation.load();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
         if (operation == null) return;
 
         Map<Integer, TargetVillage> targetsMap = new HashMap<>();

--- a/src/main/java/planner/MainController.java
+++ b/src/main/java/planner/MainController.java
@@ -460,8 +460,8 @@ public class MainController implements Initializable {
     /**
      * Left side navigation; updates the action variable and the labels
      */
-    public void sizeAndSpeed() {
-        action = "sizeAndSpeed";
+    public void serverDetails() {
+        action = "serverDetails";
         okButton.setVisible(false);
         infoLabel1.setText("Not implemented yet.");
         infoLabel2.setText("Defaults: size 200, speed 1");
@@ -475,7 +475,7 @@ public class MainController implements Initializable {
         okButton.setVisible(true);
         infoLabel1.setText("Paste here links to villages you want to mark as CAPITALS.");
         infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&y=99");
-        infoLabel3.setText("");
+        infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");
         pastedText.setVisible(true);
@@ -485,7 +485,7 @@ public class MainController implements Initializable {
         okButton.setVisible(true);
         infoLabel1.setText("Paste here links to villages you want to mark as OFF VILLAGES.");
         infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&amp;y=99");
-        infoLabel3.setText("");
+        infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");
         pastedText.setVisible(true);
@@ -505,7 +505,7 @@ public class MainController implements Initializable {
         okButton.setVisible(true);
         infoLabel1.setText("Paste here links to villages you want to mark as WORLD WONDERS.");
         infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&amp;y=99");
-        infoLabel3.setText("");
+        infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");
         pastedText.setVisible(true);
@@ -514,7 +514,7 @@ public class MainController implements Initializable {
         action = "smallArtes";
         okButton.setVisible(true);
         infoLabel1.setText("Paste here the source code of your treasury page for SMALL (lvl10) ARTEFACTS.");
-        infoLabel2.setText("");
+        infoLabel2.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel3.setText("");
         infoLabel4.setText("");
         pastedText.setText("");
@@ -524,7 +524,7 @@ public class MainController implements Initializable {
         action = "largeArtes";
         okButton.setVisible(true);
         infoLabel1.setText("Paste here the source code of your treasury page for LARGE (lvl20) ARTEFACTS.");
-        infoLabel2.setText("");
+        infoLabel2.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel3.setText("");
         infoLabel4.setText("");
         pastedText.setText("");

--- a/src/main/java/planner/MainController.java
+++ b/src/main/java/planner/MainController.java
@@ -321,6 +321,9 @@ public class MainController implements Initializable {
     }
 
 
+    public void markDeffs() { this.updateVillageData("deffvillage"); }
+
+
     public void markWWs() { this.updateVillageData("wwvillage");}
 
 
@@ -517,6 +520,9 @@ public class MainController implements Initializable {
             case "offs":
                 markOffs();
                 break;
+            case "deffs":
+                markDeffs();
+                break;
             case "wws":
                 markWWs();
                 break;
@@ -574,7 +580,7 @@ public class MainController implements Initializable {
         action = "offs";
         okButton.setVisible(true);
         infoLabel1.setText("Paste here links to villages you want to mark as OFF VILLAGES.");
-        infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&amp;y=99");
+        infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&y=99");
         infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");
@@ -582,19 +588,19 @@ public class MainController implements Initializable {
     }
     public void deffs() {
         action = "deffs";
-        okButton.setVisible(false);
-        infoLabel1.setText("Not implemented yet.");
-        infoLabel2.setText("");
-        infoLabel3.setText("");
+        okButton.setVisible(true);
+        infoLabel1.setText("Paste here links to villages you want to mark as DEF VILLAGES.");
+        infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&y=99");
+        infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");
-        pastedText.setVisible(false);
+        pastedText.setVisible(true);
     }
     public void wws() {
         action = "wws";
         okButton.setVisible(true);
         infoLabel1.setText("Paste here links to villages you want to mark as WORLD WONDERS.");
-        infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&amp;y=99");
+        infoLabel2.setText("One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&y=99");
         infoLabel3.setText("To see the changes, save and load the operation or create a new one.");
         infoLabel4.setText("");
         pastedText.setText("");

--- a/src/main/java/planner/PlanSceneController.java
+++ b/src/main/java/planner/PlanSceneController.java
@@ -175,9 +175,14 @@ public class PlanSceneController implements Initializable {
      * Loads last saved operation from database.
      */
     public void loadOperation() {
-
-        this.operation = Operation.load();
-        initOperation();
+        try {
+            this.operation = Operation.load();
+            if (this.operation != null) {
+                initOperation();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
 

--- a/src/main/java/planner/PlanSceneController.java
+++ b/src/main/java/planner/PlanSceneController.java
@@ -64,6 +64,9 @@ public class PlanSceneController implements Initializable {
     CheckBox offs;
 
     @FXML
+    CheckBox deffs;
+
+    @FXML
     CheckBox small_artes;
 
     @FXML
@@ -319,6 +322,7 @@ public class PlanSceneController implements Initializable {
                     && (
                     (target.isCapital() && this.caps.isSelected())
                             || (target.isOffvillage() && this.offs.isSelected())
+                            || (target.isDeffvillage() && this.deffs.isSelected())
                             || (target.getArtefact().contains("Small") && this.small_artes.isSelected())
                             || (target.getArtefact().contains("Large") && this.large_artes.isSelected())
                             || (target.getArtefact().contains("Unique") && this.large_artes.isSelected())

--- a/src/main/java/planner/PlanSceneController.java
+++ b/src/main/java/planner/PlanSceneController.java
@@ -274,7 +274,7 @@ public class PlanSceneController implements Initializable {
     /**
      * Master update method; first triggers the update in the Operation object and then redraws the screen.
      */
-    private void updateCycle() {
+    public void updateCycle() {
 
         if (operation != null) {
 
@@ -325,12 +325,11 @@ public class PlanSceneController implements Initializable {
             }
         }
 
-        // Checkbox for planned attacks should show all planned attacks for selected alliances
+        // Checkbox for planned attacks should show all planned attacks
         if (planned_attacks.isSelected()) {
             for (AttackerVillage attackerVillage : operation.getAttackers()) {
                 for (Attack attack : attackerVillage.getPlannedAttacks()) {
-                    if (!shownVillages.contains(attack.getTarget())
-                            && enemyAlliances.contains(attack.getTarget().getAllyName())) {
+                    if (!shownVillages.contains(attack.getTarget())) {
                         shownVillages.add(attack.getTarget());
                     }
                 }

--- a/src/main/java/planner/entities/Attack.java
+++ b/src/main/java/planner/entities/Attack.java
@@ -8,10 +8,12 @@ import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -135,8 +137,23 @@ public class Attack {
         r4.setMaxHeight(2);
         r4.setMinHeight(2);
         offs.getChildren().add(r4);
-        offs.getChildren().add(attacker.offIconRow());
-        offs.getChildren().add(new Label(attacker.offSizeRounded()));
+        HBox offIconRow = attacker.offIconRow();
+        Tooltip offStringTooltip = new Tooltip(
+                attacker.getOffString() + "\n" +
+                        "Earliest send: " + attacker.getSendMin() + "\n" +
+                        "Latest send: " + attacker.getSendMax()+ "\n" +
+                        "Comment: " + attacker.getComment());
+        offStringTooltip.setShowDelay(Duration.millis(0));
+        offStringTooltip.setHideDelay(Duration.millis(500));
+        offStringTooltip.setShowDuration(Duration.INDEFINITE);
+        offStringTooltip.setMaxWidth(200);
+        offStringTooltip.setWrapText(true);
+        Tooltip.install(offIconRow, offStringTooltip);
+        offs.getChildren().add(offIconRow);
+        Label shortOffSizeString = new Label(attacker.offSizeRounded());
+        shortOffSizeString.setTooltip(offStringTooltip);
+        offs.getChildren().add(shortOffSizeString);
+
         for (Node n : offs.getChildren()) n.getStyleClass().add("attack-box-off-column");
         box.getChildren().add(offs);
 
@@ -201,6 +218,8 @@ public class Attack {
 
     @Override
     public String toString() {
-        return attacker.toString() + " " + this.getSendingTime().format(App.TIME_ONLY);
+        String ret = "";
+        if (this.waves > 0) ret = "- ";
+        return ret + attacker.toString() + " " + this.getSendingTime().format(App.TIME_ONLY);
     }
 }

--- a/src/main/java/planner/entities/AttackerVillage.java
+++ b/src/main/java/planner/entities/AttackerVillage.java
@@ -443,7 +443,7 @@ public class AttackerVillage extends Village {
         switch (this.getTribe()) {
             case 1:
                 ret[0] = 37; // imperian
-                ret[1] = 73; // ei
+                ret[1] = 74; // ei
                 break;
             case 2:
                 ret[0] = 0; // club

--- a/src/main/java/planner/entities/Operation.java
+++ b/src/main/java/planner/entities/Operation.java
@@ -333,10 +333,10 @@ public class Operation {
      * @return Operation object or null if there was a problem.
      * TODO move DB operations to the Database class
      */
-    public static Operation load() {
+    public static Operation load() throws SQLException {
         Operation operation = new Operation();
+        Connection conn = DriverManager.getConnection(App.DB);
         try {
-            Connection conn = DriverManager.getConnection(App.DB);
             // Get landing time and flex seconds
             ResultSet rs1 = conn.prepareStatement("SELECT * FROM operation_meta").executeQuery();
             while (rs1.next()) {
@@ -396,8 +396,9 @@ public class Operation {
             // Compute landing times for all attacks
             operation.computeLandingTimes(false);
             conn.close();
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
+            conn.close();
             return null;
         }
         return operation;

--- a/src/main/java/planner/entities/Operation.java
+++ b/src/main/java/planner/entities/Operation.java
@@ -94,6 +94,7 @@ public class Operation {
                 TargetVillage t = new TargetVillage(rs.getInt("coordId"));
                 if (rs.getInt("capital") == 1) t.setCapital(true);
                 if (rs.getInt("offvillage") == 1) t.setOffvillage(true);
+                if (rs.getInt("deffvillage") == 1) t.setDeffvillage(true);
                 if (rs.getInt("wwvillage") == 1) t.setWwvillage(true);
                 int small = rs.getInt("small_arte");
                 int large = rs.getInt("large_arte");

--- a/src/main/java/planner/entities/TargetVillage.java
+++ b/src/main/java/planner/entities/TargetVillage.java
@@ -16,6 +16,9 @@ public class TargetVillage extends Village {
     private boolean offvillage = false;
 
     @Getter @Setter
+    private boolean deffvillage = false;
+
+    @Getter @Setter
     private boolean wwvillage = false;
 
     @Getter @Setter

--- a/src/main/resources/planner/main.css
+++ b/src/main/resources/planner/main.css
@@ -1,3 +1,12 @@
 .label {
     -fx-text-fill: black;
 }
+
+.button {
+    -fx-min-width: 121px;
+    -fx-max-width: 121px;
+}
+
+.hidden {
+
+}

--- a/src/main/resources/planner/main.fxml
+++ b/src/main/resources/planner/main.fxml
@@ -13,15 +13,20 @@
             <HBox       spacing="24" >
                 <Button     text="Back to planning"
                             onAction="#toPlanning" />
-                <Label  fx:id="lastUpdated" />
-                <Label  fx:id="noParticipants" />
+                <Label      fx:id="serverUrl" />
+                <Label      fx:id="serverSize" />
+                <Label      fx:id="serverSpeed" />
+                <Label      fx:id="lastUpdated" />
+                <Label      fx:id="noParticipants" />
             </HBox>
             <HBox       spacing="24" >
                 <VBox       spacing="4" >
-                    <Button text="Choose map.sql"
-                            onAction="#loadMapsql" />
                     <Button text="Server details"
                             onAction="#serverDetails" />
+                    <Button text="Fetch map.sql"
+                            onAction="#downloadMapSql" />
+                    <Button text="Choose map.sql"
+                            onAction="#loadMapsql" />
                     <Button text="Input caps"
                             onAction="#capitals" />
                     <Button text="Input offs"

--- a/src/main/resources/planner/main.fxml
+++ b/src/main/resources/planner/main.fxml
@@ -6,56 +6,57 @@
 <AnchorPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="planner.MainController"
-            prefWidth="1280.0" prefHeight="800.0">
-    <VBox   spacing="4" >
-        <HBox>
-            <Button text="Choose map.sql"
-                    onAction="#loadMapsql" />
-            <Label  fx:id="lastUpdated" />
-        </HBox>
-        <Label      text="Paste here links to villages you want to mark as caps, offs, or WWs, and press the corresponding button." />
-        <Label      text="One per line, format example: https://ts4.nordics.travian.com/position_details.php?x=-74&amp;y=99" />
-        <TextArea   maxWidth="300"
-                    maxHeight="100"
-                    fx:id="villageInfo" />
-        <HBox>
-            <Button text="Mark as caps"
-                    onAction="#markCapitals" />
-            <Button text="Mark as offs"
-                    onAction="#markOffs" />
-            <Button text="Mark as WWs"
-                    onAction="#markWWs" />
-        </HBox>
-        <Label      text="Paste here the source code of your treasury page for small/large artefacts." />
-        <Label      text="Press the corresponding button to import artefact data." />
-        <TextArea   maxWidth="300"
-                    maxHeight="100"
-                    fx:id="artefactInfo" />
-        <HBox>
-            <Button text="Small artefacts"
-                    onAction="#parseSmall" />
-            <Button text="Large artefacts"
-                    onAction="#parseLarge" />
-        </HBox>
-        <Label      text="Paste participant rows from sheets, exactly in the following format:" />
-        <Label      text="timestamp account x y ts speed tribe offsize catas chiefs sendmin sendmax comment" />
-        <Label      text="Example: 3/26/2020 22:46:59	Haamu	-73	138	18	1	Gaul	100+0+0+109+106	106	3	13:00:00	00:00:00	No night sends																			" />
-        <Label      text="Warning! This will remove all existing participants and their planned attacks." />
-        <TextArea   maxWidth="300"
-                    maxHeight="100"
-                    fx:id="participants" />
-        <HBox>
-            <Button text="New operation"
-                    onAction="#loadParticipants" />
-            <Label  fx:id="noParticipants" />
-        </HBox>
-        <Label      text="Load the last saved operation from database:" />
-        <Button     text="Load operation"
-                    onAction="#load" />
-        <Button     fx:id="planButton"
-                    text="Plan!"
-                    prefWidth="150"
-                    prefHeight="100"
-                    onAction="#toPlanning" />
-    </VBox>
+            prefHeight="800.0" prefWidth="1280.0">
+    <HBox>
+        <Region     maxWidth="4" minWidth="4" />
+        <VBox       spacing="8" >
+            <HBox       spacing="24" >
+                <Button     text="Back to planning"
+                            onAction="#toPlanning" />
+                <Label  fx:id="lastUpdated" />
+                <Label  fx:id="noParticipants" />
+            </HBox>
+            <HBox       spacing="24" >
+                <VBox       spacing="4" >
+                    <Button text="Choose map.sql"
+                            onAction="#loadMapsql" />
+                    <Button text="Set size+speed"
+                            onAction="#sizeAndSpeed" />
+                    <Button text="Input caps"
+                            onAction="#capitals" />
+                    <Button text="Input offs"
+                            onAction="#offs" />
+                    <Button text="Input deffs"
+                            onAction="#deffs" />
+                    <Button text="Input WWs"
+                            onAction="#wws" />
+                    <Button text="Small artefacts"
+                            onAction="#smallArtes" />
+                    <Button text="Large artefacts"
+                            onAction="#largeArtes" />
+                    <Button text="New operation"
+                            onAction="#newOperation" />
+                    <Button     text="Load operation"
+                                onAction="#loadOperation" />
+                </VBox>
+                <VBox       spacing="4" >
+                    <Label      text="Choose action from the left side"
+                                fx:id="infoLabel1" />
+                    <Label      fx:id="infoLabel2" />
+                    <Label      fx:id="infoLabel3" />
+                    <Label      fx:id="infoLabel4" />
+                    <TextArea   minWidth="1100"
+                                maxWidth="1100"
+                                minHeight="191"
+                                maxHeight="191"
+                                visible="false"
+                                fx:id="pastedText" />
+                    <Button     text="OK"
+                                visible="false"
+                                onAction="#doAction"
+                                fx:id="okButton" />
+                </VBox>
+            </HBox>
+        </VBox>
+    </HBox>
 </AnchorPane>

--- a/src/main/resources/planner/main.fxml
+++ b/src/main/resources/planner/main.fxml
@@ -7,7 +7,8 @@
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="planner.MainController"
             prefHeight="800.0" prefWidth="1280.0">
-    <HBox>
+    <HBox       minWidth="1280"
+                maxWidth="1280" >
         <Region     maxWidth="4" minWidth="4" />
         <VBox       spacing="8" >
             <HBox       spacing="24" >
@@ -43,6 +44,8 @@
                             onAction="#newOperation" />
                     <Button     text="Load operation"
                                 onAction="#loadOperation" />
+                    <Button     text="Add participants"
+                                onAction="#participants" />
                 </VBox>
                 <VBox       spacing="4" >
                     <Label      text="Choose action from the left side"

--- a/src/main/resources/planner/main.fxml
+++ b/src/main/resources/planner/main.fxml
@@ -32,7 +32,7 @@
                             onAction="#capitals" />
                     <Button text="Input offs"
                             onAction="#offs" />
-                    <Button text="Input deffs"
+                    <Button text="Input defs"
                             onAction="#deffs" />
                     <Button text="Input WWs"
                             onAction="#wws" />

--- a/src/main/resources/planner/main.fxml
+++ b/src/main/resources/planner/main.fxml
@@ -20,8 +20,8 @@
                 <VBox       spacing="4" >
                     <Button text="Choose map.sql"
                             onAction="#loadMapsql" />
-                    <Button text="Set size+speed"
-                            onAction="#sizeAndSpeed" />
+                    <Button text="Server details"
+                            onAction="#serverDetails" />
                     <Button text="Input caps"
                             onAction="#capitals" />
                     <Button text="Input offs"

--- a/src/main/resources/planner/plan.fxml
+++ b/src/main/resources/planner/plan.fxml
@@ -11,7 +11,7 @@
                 maxWidth="1280">
             <Region         minWidth="4"
                             maxWidth="4" />
-            <VBox>
+            <VBox           spacing="4" >
                 <Label      text="Tools"
                             minHeight="20"
                             maxHeight="20" />
@@ -75,8 +75,8 @@
                             alignment="BASELINE_RIGHT"
                             onAction="#updateTimes" />
                 <Region     VBox.vgrow="ALWAYS"
-                            minHeight="5"
-                            maxHeight="5" />
+                            minHeight="4"
+                            maxHeight="4" />
                 <HBox       minWidth="160"
                             maxWidth="160" >
                     <Button     text="Randomise"
@@ -95,6 +95,9 @@
                                 maxHeight="30"
                                 alignment="TOP_RIGHT" />
                 </HBox>
+                <Region     VBox.vgrow="ALWAYS"
+                            minHeight="1"
+                            maxHeight="1" />
                 <Button     fx:id="optimiseButton"
                             minWidth="140"
                             maxWidth="140"

--- a/src/main/resources/planner/plan.fxml
+++ b/src/main/resources/planner/plan.fxml
@@ -12,12 +12,33 @@
             <Region         minWidth="4"
                             maxWidth="4" />
             <VBox>
+                <Label      text="Tools"
+                            minHeight="20"
+                            maxHeight="20" />
+                <Button     text="Data updates"
+                            minWidth="110"
+                            maxWidth="110"
+                            onAction="#toUpdating" />
+                <Button     text="Commands"
+                            minWidth="110"
+                            maxWidth="110"
+                            onAction="#toCommands" />
+                <Button     text="Save"
+                            minWidth="110"
+                            maxWidth="110"
+                            onAction="#save" />
+                <Label      fx:id="savedText" />
+            </VBox>
+            <Region         minWidth="8"
+                            maxWidth="8" />
+            <VBox>
                 <Label      text="Pick enemies"
                             minHeight="20"
                             maxHeight="20" />
                 <ScrollPane minWidth="130"
                             maxWidth="130"
-                            maxHeight="280"
+                            minHeight="260"
+                            maxHeight="260"
                             hbarPolicy="NEVER">
                     <VBox   fx:id="enemyTickboxes" />
                 </ScrollPane>
@@ -38,7 +59,7 @@
                         <CheckBox   fx:id="small_artes" text="Small artefacts" />
                         <CheckBox   fx:id="large_artes" text="Large artefacts" />
                         <CheckBox   fx:id="bps_wws" text="BP/WW" />
-                        <CheckBox   fx:id="planned_attacks" text="Planned attacks" />
+                        <CheckBox   fx:id="planned_attacks" text="Planned attacks" selected="true" />
                     </VBox>
                 </ScrollPane>
             </VBox>
@@ -78,26 +99,6 @@
                             minWidth="140"
                             maxWidth="140"
                             onAction="#optimiseTimes" />
-            </VBox>
-            <Region         minWidth="8"
-                            maxWidth="8" />
-            <VBox>
-                <Label      text="Tools"
-                            minHeight="20"
-                            maxHeight="20" />
-                <Button     text="Data updates"
-                            minWidth="110"
-                            maxWidth="110"
-                            onAction="#toUpdating" />
-                <Button     text="Commands"
-                            minWidth="110"
-                            maxWidth="110"
-                            onAction="#toCommands" />
-                <Button     text="Save"
-                            minWidth="110"
-                            maxWidth="110"
-                            onAction="#save" />
-                <Label      fx:id="savedText" />
             </VBox>
             <Region         minWidth="8"
                             maxWidth="8" />

--- a/src/main/resources/planner/plan.fxml
+++ b/src/main/resources/planner/plan.fxml
@@ -56,6 +56,7 @@
                     <VBox   fx:id="targetTickboxes" >
                         <CheckBox   fx:id="caps" text="Capitals" />
                         <CheckBox   fx:id="offs" text="Off villages" />
+                        <CheckBox   fx:id="deffs" text="Def villages" />
                         <CheckBox   fx:id="small_artes" text="Small artefacts" />
                         <CheckBox   fx:id="large_artes" text="Large artefacts" />
                         <CheckBox   fx:id="bps_wws" text="BP/WW" />


### PR DESCRIPTION
Quality of life updates and bugfixes:
- Loads last operation automatically when starting up
- Opens with planned attacks open by default
- Automatically retrieves a new map.sql if it's more than a day old
- Button for manually retrieving map.sql as well
- Allow for editing the server size and speed
- Revisit data update screen
- Tooltip to show attacker details also on the target rows
- Possible to add new participants to an existing operation
- Possible to mark targets as def villages